### PR TITLE
Add commit analyzer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib"]
 	path = lib
-	url = git@github.com:thenickcox/commit_analyzer.git
+	url = git@github.com:CenturyLinkCloud/KB-Commit-Analyzer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "lib"]
+	path = lib
+	url = git@github.com:thenickcox/commit_analyzer.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: node_js
+
+# Following from http://stackoverflow.com/a/24600210/931934
+#
+# Handle git submodules yourself
+git:
+  submodules: false
+# Use sed to replace the SSH URL with the public URL, then initialize submodules
+before_install:
+node_js:
+  - '0.12'
+before_install:
+  - git submodule foreach 'git fetch && git fetch --tags'
+  - sed -i 's/git@github.com:/https:\/\/github.com\//' .gitmodules
+  - git submodule update --init --recursive
+  - npm install -g npm@latest
+  - cd lib && npm install && ls
+script: node index.js

--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ To run this check locally, `cd` into the root of this project and run:
 node lib/index.js
 ```
 
+_Note that the first time you wish to run the commit analyzer, you'll have to run `npm install` from the `lib` directory. This assumes you have [Node.js](http://nodejs.org) installed._
+
 The output will tell you if any file fails parsing. This script is also run as part of continuous integration with [travis-ci](http://travis-ci.org).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ so like this (folder names are case-sensitive):
 
 ### Commit Analyzer
 
-This repository contains a [commit analyzer](https://github.com/thenickcox/commit_analyzer) that runs against each file in the repository validating that the following are true:
+This repository contains a [commit analyzer](https://github.com/CenturyLinkCloud/KB-Commit-Analyzer) that runs against each file in the repository validating that the following are true:
 
 * File's JSON front-matter parses correctly and contains the required fields (title, date, autor)
 * File's markdown successfully parses
@@ -34,3 +34,7 @@ node lib/index.js
 _Note that the first time you wish to run the commit analyzer, you'll have to run `npm install` from the `lib` directory. This assumes you have [Node.js](http://nodejs.org) installed._
 
 The output will tell you if any file fails parsing. This script is also run as part of continuous integration with [travis-ci](http://travis-ci.org).
+
+#### Ignoring Files
+
+If a file contains a link that the commit analyzer catches as being invalid (such as in a code sample), and you'd like the analyzer to ignore that file, you can add the filename to `commit_analyzer_ignore.txt`. (It isn't necessary to include the entire file path; just the filename will suffice.) Each new file should be separated by a new line.

--- a/README.md
+++ b/README.md
@@ -16,3 +16,19 @@ so like this (folder names are case-sensitive):
 [API v2.0 Overview](../Getting Started/api-v2-overview.md)
 [Login](../Authentication/login.md )
 ```
+
+### Commit Analyzer
+
+This repository contains a [commit analyzer](https://github.com/thenickcox/commit_analyzer) that runs against each file in the repository validating that the following are true:
+
+* File's JSON front-matter parses correctly and contains the required fields (title, date, autor)
+* File's markdown successfully parses
+* All relative files (images and other markdown files) are valid links
+
+To run this check locally, `cd` into the root of this project and run:
+
+```shell
+node lib/index.js
+```
+
+The output will tell you if any file fails parsing. This script is also run as part of continuous integration with [travis-ci](http://travis-ci.org).


### PR DESCRIPTION
This commit adds the commit analyzer to check the JSON front-matter, markdown parsing, and relative links to other files (images and other markdown files) to be run on Travis CI.