### PR TITLE
Fix incorrect/inconsistent querystring parameter name

### DIFF
--- a/Firewall Policies/get-cross-dc-firewall-policy-list.md
+++ b/Firewall Policies/get-cross-dc-firewall-policy-list.md
@@ -18,11 +18,11 @@ Use this API operation when you need the list of available firewall policies bet
 
 ### Structure
 
-    GET https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/{sourceAccountAlias}/{dataCenter}?destinationAccountId=<other account id>
+    GET https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/{sourceAccountId}/{dataCenter}?destinationAccountId=<other account id>
 
 ### Example
 
-    GET https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/SRC_ALIAS/VA1?destinationAccountAlias=DEST_ALIAS
+    GET https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/SRC_ALIAS/VA1?destinationAccountId=DEST_ALIAS
 
 ## Request
 
@@ -30,9 +30,9 @@ Use this API operation when you need the list of available firewall policies bet
 
 | Name | Type | Description | Req. |
 | --- | --- | --- | --- |
-| sourceAccountAlias | string | Short code for a particular account | Yes |
+| sourceAccountId | string | Short code for a particular account | Yes |
 | dataCenter | string | Short string representing the target data center for the new policy. Valid codes can be retrieved from the [Get Data Center List](https://www.ctl.io/api-docs/v2/#data-centers-get-data-center) API operation. | Yes |
-| destinationAccountAlias | string | Short string for another account | No |
+| destinationAccountId | string | Short code for another account | No |
 
 ## Response
 


### PR DESCRIPTION
https://t3n.zendesk.com/agent/tickets/1297432

Customer pointed out incorrect documentation in the `v2-experimental/crossDcFirewallPolicies/` endpoint.