### PR TITLE
Fixed an issue with the incorrect token identifier being used

### DIFF
--- a/Firewall Policies/get-cross-dc-firewall-policy-list.md
+++ b/Firewall Policies/get-cross-dc-firewall-policy-list.md
@@ -18,7 +18,7 @@ Use this API operation when you need the list of available firewall policies bet
 
 ### Structure
 
-    GET https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/{sourceAccountId}/{dataCenter}?destinationAccountId=<other account id>
+    GET https://api.ctl.io/v2-experimental/crossDcFirewallPolicies/{sourceAccountId}/{dataCenter}?destinationAccountId={destinationAccountId}
 
 ### Example
 


### PR DESCRIPTION
This causes an issue with the clc go cli tests. See [this](https://github.com/CenturyLinkCloud/clc-go-cli/issues/73) issue for further information.
