### PR TITLE
Updated so that recursive element is defined consistently

### DIFF
--- a/Webhooks/set-webhook.md
+++ b/Webhooks/set-webhook.md
@@ -33,7 +33,7 @@ Use this API operation when you want to change the configuration of a webhook in
 
 | Name | Type | Description | Req. |
 | --- | --- | --- | --- |
-| recursive | string | If true, the webhook is called when the event occurs in sub-accounts | Yes |
+| recursive | boolean | If true, the webhook will be called when the event occurs in a sub-accounts | Yes |
 | targetUris | TargetUri[] | The targets called when the event occurs | No |
 
 #### TargetUri Entity Definition


### PR DESCRIPTION
The webhook get and set document defined the 'recursive' element consistently.  Changed the webhook set to be data type boolean like the webhook get.
